### PR TITLE
Discogs: Implement collection value entities

### DIFF
--- a/homeassistant/components/discogs/sensor.py
+++ b/homeassistant/components/discogs/sensor.py
@@ -29,7 +29,7 @@ DEFAULT_NAME = "Discogs"
 
 ICON_RECORD = "mdi:album"
 ICON_PLAYER = "mdi:record-player"
-ICON_CASH = "mdi:cash" # Icon for monetary values
+ICON_CASH = "mdi:cash"  # Icon for monetary values
 UNIT_RECORDS = "records"
 UNIT_CURRENCY = "$"
 
@@ -135,7 +135,7 @@ def setup_platform(
 class DiscogsSensor(SensorEntity):
     """Create a new Discogs sensor for a specific type."""
 
-    _attr_attribution = "Data provided by Discogs" # Standard way to add attribution
+    _attr_attribution = "Data provided by Discogs"  # Standard way to add attribution
 
     def __init__(
         self, discogs_data, name, description: SensorEntityDescription
@@ -143,7 +143,7 @@ class DiscogsSensor(SensorEntity):
         """Initialize the Discogs sensor."""
         self.entity_description = description
         self._discogs_data = discogs_data
-        self._attrs: dict = {} # Used for random record details
+        self._attrs: dict = {}  # Used for random record details
 
         self._attr_name = f"{name} {description.name}"
 
@@ -155,7 +155,7 @@ class DiscogsSensor(SensorEntity):
 
         if (
             self.entity_description.key == SENSOR_RANDOM_RECORD_TYPE
-            and self._attrs # Check if _attrs has data for random record
+            and self._attrs  # Check if _attrs has data for random record
         ):
             return {
                 "cat_no": self._attrs["labels"][0]["catno"],
@@ -185,7 +185,7 @@ class DiscogsSensor(SensorEntity):
                 f"{random_record.data['artists'][0]['name']} -"
                 f" {random_record.data['title']}"
             )
-        return None # Return None if collection is empty
+        return None  # Return None if collection is empty
 
     def update(self) -> None:
         """Set state to the amount of records or collection value."""
@@ -194,10 +194,16 @@ class DiscogsSensor(SensorEntity):
         elif self.entity_description.key == SENSOR_WANTLIST_TYPE:
             self._attr_native_value = self._discogs_data["wantlist_count"]
         elif self.entity_description.key == SENSOR_COLLECTION_VALUE_MIN_TYPE:
-            self._attr_native_value = float(self._discogs_data["collection_value_min"].replace(UNIT_CURRENCY, ''))
+            self._attr_native_value = float(
+                self._discogs_data["collection_value_min"].replace(UNIT_CURRENCY, "")
+            )
         elif self.entity_description.key == SENSOR_COLLECTION_VALUE_MEDIAN_TYPE:
-            self._attr_native_value = float(self._discogs_data["collection_value_median"].replace(UNIT_CURRENCY, ''))
+            self._attr_native_value = float(
+                self._discogs_data["collection_value_median"].replace(UNIT_CURRENCY, "")
+            )
         elif self.entity_description.key == SENSOR_COLLECTION_VALUE_MAX_TYPE:
-            self._attr_native_value = float(self._discogs_data["collection_value_max"].replace(UNIT_CURRENCY, ''))
-        else: # SENSOR_RANDOM_RECORD_TYPE
+            self._attr_native_value = float(
+                self._discogs_data["collection_value_max"].replace(UNIT_CURRENCY, "")
+            )
+        else:  # SENSOR_RANDOM_RECORD_TYPE
             self._attr_native_value = self.get_random_record()

--- a/homeassistant/components/discogs/sensor.py
+++ b/homeassistant/components/discogs/sensor.py
@@ -10,29 +10,26 @@ import discogs_client
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA, # Renamed PLATFORM_SCHEMA
+    PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
     SensorEntity,
-    SensorEntityDescription, # New import for sensor descriptions
+    SensorEntityDescription,
 )
 from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_TOKEN
-from homeassistant.core import HomeAssistant # New import for HomeAssistant type
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import SERVER_SOFTWARE
-from homeassistant.helpers.entity_platform import AddEntitiesCallback # New import for callback type
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType # New imports for typing
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_IDENTITY = "identity"
 
-# ATTRIBUTION is now typically handled via _attr_attribution in the entity class
-# ATTRIBUTION = "Data provided by Discogs" # Remove this line
-
 DEFAULT_NAME = "Discogs"
 
 ICON_RECORD = "mdi:album"
 ICON_PLAYER = "mdi:record-player"
-ICON_CASH = "mdi:cash"
+ICON_CASH = "mdi:cash" # Icon for monetary values
 UNIT_RECORDS = "records"
 UNIT_CURRENCY = "$"
 
@@ -45,7 +42,7 @@ SENSOR_COLLECTION_VALUE_MIN_TYPE = "collection_value_min"
 SENSOR_COLLECTION_VALUE_MEDIAN_TYPE = "collection_value_median"
 SENSOR_COLLECTION_VALUE_MAX_TYPE = "collection_value_max"
 
-# SENSORS dictionary is replaced by SENSOR_TYPES tuple of SensorEntityDescription objects
+# Define sensor entities using SensorEntityDescription for modern Home Assistant standards
 SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key=SENSOR_COLLECTION_TYPE,
@@ -63,30 +60,28 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key=SENSOR_RANDOM_RECORD_TYPE,
         name="Random Record",
         icon=ICON_PLAYER,
-        # unit_of_measurement is None, so it's omitted
     ),
-    SensorEntityDescription( # New sensor definition for min value
+    SensorEntityDescription(
         key=SENSOR_COLLECTION_VALUE_MIN_TYPE,
         name="Collection Value (Min)",
         icon=ICON_CASH,
         native_unit_of_measurement=UNIT_CURRENCY,
     ),
-    SensorEntityDescription( # New sensor definition for median value
+    SensorEntityDescription(
         key=SENSOR_COLLECTION_VALUE_MEDIAN_TYPE,
         name="Collection Value (Median)",
         icon=ICON_CASH,
         native_unit_of_measurement=UNIT_CURRENCY,
     ),
-    SensorEntityDescription( # New sensor definition for max value
+    SensorEntityDescription(
         key=SENSOR_COLLECTION_VALUE_MAX_TYPE,
         name="Collection Value (Max)",
         icon=ICON_CASH,
         native_unit_of_measurement=UNIT_CURRENCY,
     ),
 )
-SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES] # Automatically generate keys from descriptions
+SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
 
-# PLATFORM_SCHEMA now uses SENSOR_PLATFORM_SCHEMA from homeassistant.components.sensor
 PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_TOKEN): cv.string,
@@ -137,7 +132,6 @@ def setup_platform(
     add_entities(entities, True)
 
 
-# Class now inherits from SensorEntity
 class DiscogsSensor(SensorEntity):
     """Create a new Discogs sensor for a specific type."""
 
@@ -149,16 +143,14 @@ class DiscogsSensor(SensorEntity):
         """Initialize the Discogs sensor."""
         self.entity_description = description
         self._discogs_data = discogs_data
-        self._attrs: dict = {} # For random record details
+        self._attrs: dict = {} # Used for random record details
 
-        # Set entity name using description.name
         self._attr_name = f"{name} {description.name}"
 
     @property
     def extra_state_attributes(self):
         """Return the device state attributes of the sensor."""
-        # Use _attr_native_value for the current state value
-        if self._attr_native_value is None: # Removed _attrs check, as it might be empty for some sensor types
+        if self._attr_native_value is None:
             return None
 
         if (
@@ -173,16 +165,14 @@ class DiscogsSensor(SensorEntity):
                 ),
                 "label": self._attrs["labels"][0]["name"],
                 "released": self._attrs["year"],
-                # ATTR_ATTRIBUTION is now handled by _attr_attribution
                 ATTR_IDENTITY: self._discogs_data["user"],
             }
-        # For all other sensor types (collection count, wantlist count, collection value)
-        # the identity attribute is sufficient, and attribution is handled by _attr_attribution
+        # For all other sensor types, only identity is needed as attribution is handled by _attr_attribution
         return {
             ATTR_IDENTITY: self._discogs_data["user"],
         }
 
-    def get_random_record(self) -> str | None: # Type hint for return
+    def get_random_record(self) -> str | None:
         """Get a random record suggestion from the user's collection."""
         # Index 0 in the folders is the 'All' folder
         collection = self._discogs_data["folders"][0]
@@ -197,9 +187,8 @@ class DiscogsSensor(SensorEntity):
             )
         return None # Return None if collection is empty
 
-    def update(self) -> None: # Type hint for return
+    def update(self) -> None:
         """Set state to the amount of records or collection value."""
-        # Use self.entity_description.key to identify the sensor type
         if self.entity_description.key == SENSOR_COLLECTION_TYPE:
             self._attr_native_value = self._discogs_data["collection_count"]
         elif self.entity_description.key == SENSOR_WANTLIST_TYPE:


### PR DESCRIPTION
## Proposed change
This PR enhances the Home Assistant Discogs integration by introducing new sensor entities to display the estimated monetary value of a user's record collection.
note: not an experienced dev, i did changes with help from gemini.

The Discogs API provides "collection value" data, offering minimum, median, and maximum estimated values for a user's entire collection. This feature leverages that data to create three distinct sensors in Home Assistant:

- **Discogs Collection Value (Min)**: Displays the minimum estimated value of the collection.
- **Discogs Collection Value (Median)**: Displays the median estimated value of the collection.
- **Discogs Collection Value (Max)**: Displays the maximum estimated value of the collection.

These new sensors provide valuable insight for users tracking their music assets within Home Assistant, allowing for trends, automation based on value changes, and quick glances at their collection's worth.

**Technical Changes:**

1.  **New SensorEntityDescriptions**: Introduced `SensorEntityDescription` objects for `collection_value_min`, `collection_value_median`, and `collection_value_max` within the `SENSOR_TYPES` tuple. This aligns with modern Home Assistant sensor integration practices.
    * Assigned `mdi:cash` as the icon and `$` as the `native_unit_of_measurement` for these value sensors.
2.  **API Integration**: Modified `setup_platform` to fetch the `collection_value` data from the Discogs API using `_discogs_client.identity().collection_value`.
3.  **State Handling**: In the `DiscogsSensor`'s `update` method, the fetched string values (e.g., "$123.45") are processed to remove the currency symbol and converted to `float` for correct numeric representation and graphing in Home Assistant.
4.  **Error Handling**: Enhanced the `try-except` block in `setup_platform` to provide more specific error logging for API token issues.
5.  **Refactoring & Cleanup**:
    * Updated imports and variable usage to reflect the refactoring in the core `sensor` component, including the use of `SensorEntity` and `_attr_native_value`.
    * Removed the global `ATTRIBUTION` constant as attribution is now handled via `_attr_attribution` on the `SensorEntity`.
    * Adjusted `extra_state_attributes` logic to fit the new sensor types and `SensorEntity` structure.
    * Added a check for empty collections in `get_random_record` to prevent potential errors.

**Configuration Example (in `configuration.yaml`):**

```yaml
sensor:
  - platform: discogs
    token: YOUR_DISCOGS_API_TOKEN
    name: My Discogs
    monitored_conditions:
      - collection
      - wantlist
      - random_record
      - collection_value_min
      - collection_value_median
      - collection_value_max