### PR TITLE
fix: Discogs - Localize collection value currency

### DIFF
--- a/homeassistant/components/discogs/sensor.py
+++ b/homeassistant/components/discogs/sensor.py
@@ -29,9 +29,9 @@ DEFAULT_NAME = "Discogs"
 
 ICON_RECORD = "mdi:album"
 ICON_PLAYER = "mdi:record-player"
-ICON_CASH = "mdi:cash"  # Icon for monetary values
+ICON_CASH = "mdi:cash"
 UNIT_RECORDS = "records"
-UNIT_CURRENCY = "$"
+# UNIT_CURRENCY = "$" # This will now be dynamically determined
 
 SCAN_INTERVAL = timedelta(minutes=10)
 
@@ -42,7 +42,9 @@ SENSOR_COLLECTION_VALUE_MIN_TYPE = "collection_value_min"
 SENSOR_COLLECTION_VALUE_MEDIAN_TYPE = "collection_value_median"
 SENSOR_COLLECTION_VALUE_MAX_TYPE = "collection_value_max"
 
+
 # Define sensor entities using SensorEntityDescription for modern Home Assistant standards
+# Note: For collection value sensors, native_unit_of_measurement will be set dynamically in __init__
 SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key=SENSOR_COLLECTION_TYPE,
@@ -65,19 +67,19 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key=SENSOR_COLLECTION_VALUE_MIN_TYPE,
         name="Collection Value (Min)",
         icon=ICON_CASH,
-        native_unit_of_measurement=UNIT_CURRENCY,
+        # native_unit_of_measurement is set dynamically
     ),
     SensorEntityDescription(
         key=SENSOR_COLLECTION_VALUE_MEDIAN_TYPE,
         name="Collection Value (Median)",
         icon=ICON_CASH,
-        native_unit_of_measurement=UNIT_CURRENCY,
+        # native_unit_of_measurement is set dynamically
     ),
     SensorEntityDescription(
         key=SENSOR_COLLECTION_VALUE_MAX_TYPE,
         name="Collection Value (Max)",
         icon=ICON_CASH,
-        native_unit_of_measurement=UNIT_CURRENCY,
+        # native_unit_of_measurement is set dynamically
     ),
 )
 SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
@@ -109,6 +111,17 @@ def setup_platform(
         # Fetch collection value data
         collection_value = _discogs_client.identity().collection_value
 
+        # Extract the currency symbol from one of the value strings (e.g., "$250.00" -> "$")
+        # Assuming all values will use the same currency symbol.
+        # Fallback to "$" if extraction fails or string is empty/unexpected.
+        currency_symbol = "$"
+        if collection_value and collection_value.get("minimum"):
+            # Find the first non-digit, non-decimal character
+            for char in collection_value["minimum"]:
+                if not char.isdigit() and char != ".":
+                    currency_symbol = char
+                    break
+
         discogs_data = {
             "user": _discogs_client.identity().name,
             "folders": _discogs_client.identity().collection_folders,
@@ -117,6 +130,7 @@ def setup_platform(
             "collection_value_min": collection_value["minimum"],
             "collection_value_median": collection_value["median"],
             "collection_value_max": collection_value["maximum"],
+            "currency_symbol": currency_symbol, # Store the detected currency symbol
         }
     except discogs_client.exceptions.HTTPError as err:
         _LOGGER.error("API token is not valid or Discogs API error: %s", err)
@@ -135,7 +149,7 @@ def setup_platform(
 class DiscogsSensor(SensorEntity):
     """Create a new Discogs sensor for a specific type."""
 
-    _attr_attribution = "Data provided by Discogs"  # Standard way to add attribution
+    _attr_attribution = "Data provided by Discogs"
 
     def __init__(
         self, discogs_data, name, description: SensorEntityDescription
@@ -143,9 +157,17 @@ class DiscogsSensor(SensorEntity):
         """Initialize the Discogs sensor."""
         self.entity_description = description
         self._discogs_data = discogs_data
-        self._attrs: dict = {}  # Used for random record details
+        self._attrs: dict = {}
 
         self._attr_name = f"{name} {description.name}"
+
+        # Set the native_unit_of_measurement dynamically for value sensors
+        if description.key in [
+            SENSOR_COLLECTION_VALUE_MIN_TYPE,
+            SENSOR_COLLECTION_VALUE_MEDIAN_TYPE,
+            SENSOR_COLLECTION_VALUE_MAX_TYPE,
+        ]:
+            self._attr_native_unit_of_measurement = self._discogs_data["currency_symbol"]
 
     @property
     def extra_state_attributes(self):
@@ -155,7 +177,7 @@ class DiscogsSensor(SensorEntity):
 
         if (
             self.entity_description.key == SENSOR_RANDOM_RECORD_TYPE
-            and self._attrs  # Check if _attrs has data for random record
+            and self._attrs
         ):
             return {
                 "cat_no": self._attrs["labels"][0]["catno"],
@@ -167,14 +189,12 @@ class DiscogsSensor(SensorEntity):
                 "released": self._attrs["year"],
                 ATTR_IDENTITY: self._discogs_data["user"],
             }
-        # For all other sensor types, only identity is needed as attribution is handled by _attr_attribution
         return {
             ATTR_IDENTITY: self._discogs_data["user"],
         }
 
     def get_random_record(self) -> str | None:
         """Get a random record suggestion from the user's collection."""
-        # Index 0 in the folders is the 'All' folder
         collection = self._discogs_data["folders"][0]
         if collection.count > 0:
             random_index = random.randrange(collection.count)
@@ -185,7 +205,7 @@ class DiscogsSensor(SensorEntity):
                 f"{random_record.data['artists'][0]['name']} -"
                 f" {random_record.data['title']}"
             )
-        return None  # Return None if collection is empty
+        return None
 
     def update(self) -> None:
         """Set state to the amount of records or collection value."""
@@ -194,16 +214,21 @@ class DiscogsSensor(SensorEntity):
         elif self.entity_description.key == SENSOR_WANTLIST_TYPE:
             self._attr_native_value = self._discogs_data["wantlist_count"]
         elif self.entity_description.key == SENSOR_COLLECTION_VALUE_MIN_TYPE:
-            self._attr_native_value = float(
-                self._discogs_data["collection_value_min"].replace(UNIT_CURRENCY, "")
-            )
+            # Remove the detected currency symbol and convert to float
+            value_str = self._discogs_data["collection_value_min"]
+            # Find the index of the first digit to split the symbol from the number
+            first_digit_index = next((i for i, char in enumerate(value_str) if char.isdigit() or char == '.'), 0)
+            numeric_value_str = value_str[first_digit_index:]
+            self._attr_native_value = float(numeric_value_str)
         elif self.entity_description.key == SENSOR_COLLECTION_VALUE_MEDIAN_TYPE:
-            self._attr_native_value = float(
-                self._discogs_data["collection_value_median"].replace(UNIT_CURRENCY, "")
-            )
+            value_str = self._discogs_data["collection_value_median"]
+            first_digit_index = next((i for i, char in enumerate(value_str) if char.isdigit() or char == '.'), 0)
+            numeric_value_str = value_str[first_digit_index:]
+            self._attr_native_value = float(numeric_value_str)
         elif self.entity_description.key == SENSOR_COLLECTION_VALUE_MAX_TYPE:
-            self._attr_native_value = float(
-                self._discogs_data["collection_value_max"].replace(UNIT_CURRENCY, "")
-            )
-        else:  # SENSOR_RANDOM_RECORD_TYPE
+            value_str = self._discogs_data["collection_value_max"]
+            first_digit_index = next((i for i, char in enumerate(value_str) if char.isdigit() or char == '.'), 0)
+            numeric_value_str = value_str[first_digit_index:]
+            self._attr_native_value = float(numeric_value_str)
+        else:
             self._attr_native_value = self.get_random_record()

--- a/homeassistant/components/discogs/sensor.py
+++ b/homeassistant/components/discogs/sensor.py
@@ -130,7 +130,7 @@ def setup_platform(
             "collection_value_min": collection_value["minimum"],
             "collection_value_median": collection_value["median"],
             "collection_value_max": collection_value["maximum"],
-            "currency_symbol": currency_symbol, # Store the detected currency symbol
+            "currency_symbol": currency_symbol,  # Store the detected currency symbol
         }
     except discogs_client.exceptions.HTTPError as err:
         _LOGGER.error("API token is not valid or Discogs API error: %s", err)
@@ -167,7 +167,9 @@ class DiscogsSensor(SensorEntity):
             SENSOR_COLLECTION_VALUE_MEDIAN_TYPE,
             SENSOR_COLLECTION_VALUE_MAX_TYPE,
         ]:
-            self._attr_native_unit_of_measurement = self._discogs_data["currency_symbol"]
+            self._attr_native_unit_of_measurement = self._discogs_data[
+                "currency_symbol"
+            ]
 
     @property
     def extra_state_attributes(self):
@@ -175,10 +177,7 @@ class DiscogsSensor(SensorEntity):
         if self._attr_native_value is None:
             return None
 
-        if (
-            self.entity_description.key == SENSOR_RANDOM_RECORD_TYPE
-            and self._attrs
-        ):
+        if self.entity_description.key == SENSOR_RANDOM_RECORD_TYPE and self._attrs:
             return {
                 "cat_no": self._attrs["labels"][0]["catno"],
                 "cover_image": self._attrs["cover_image"],
@@ -217,17 +216,38 @@ class DiscogsSensor(SensorEntity):
             # Remove the detected currency symbol and convert to float
             value_str = self._discogs_data["collection_value_min"]
             # Find the index of the first digit to split the symbol from the number
-            first_digit_index = next((i for i, char in enumerate(value_str) if char.isdigit() or char == '.'), 0)
+            first_digit_index = next(
+                (
+                    i
+                    for i, char in enumerate(value_str)
+                    if char.isdigit() or char == "."
+                ),
+                0,
+            )
             numeric_value_str = value_str[first_digit_index:]
             self._attr_native_value = float(numeric_value_str)
         elif self.entity_description.key == SENSOR_COLLECTION_VALUE_MEDIAN_TYPE:
             value_str = self._discogs_data["collection_value_median"]
-            first_digit_index = next((i for i, char in enumerate(value_str) if char.isdigit() or char == '.'), 0)
+            first_digit_index = next(
+                (
+                    i
+                    for i, char in enumerate(value_str)
+                    if char.isdigit() or char == "."
+                ),
+                0,
+            )
             numeric_value_str = value_str[first_digit_index:]
             self._attr_native_value = float(numeric_value_str)
         elif self.entity_description.key == SENSOR_COLLECTION_VALUE_MAX_TYPE:
             value_str = self._discogs_data["collection_value_max"]
-            first_digit_index = next((i for i, char in enumerate(value_str) if char.isdigit() or char == '.'), 0)
+            first_digit_index = next(
+                (
+                    i
+                    for i, char in enumerate(value_str)
+                    if char.isdigit() or char == "."
+                ),
+                0,
+            )
             numeric_value_str = value_str[first_digit_index:]
             self._attr_native_value = float(numeric_value_str)
         else:


### PR DESCRIPTION
fix: Discogs - Localize collection value currency

This commit addresses a critical feedback point from previous review, ensuring the Discogs collection value sensors now correctly reflect the currency set by the user in their Discogs account settings.
Note: not an experienced dev, i did this with gemini.

Previously, the `native_unit_of_measurement` for collection value sensors was hardcoded to `$`. However, the Discogs API returns collection values with a currency symbol that varies based on the user's geographic location and account preferences (e.g., "€" for Euro, "£" for British Pound, etc.). This caused inconsistencies and incorrect display for users outside of USD regions.

This change implements dynamic currency detection and assignment:

**Changes Made:**

1.  **Dynamic Currency Extraction**: In `setup_platform`, the currency symbol (e.g., `$` or `€`) is now dynamically extracted from the `minimum` collection value string returned by the Discogs API. This symbol is then stored in `discogs_data`.
2.  **Dynamic Unit of Measurement**: The `native_unit_of_measurement` for the `collection_value_min`, `collection_value_median`, and `collection_value_max` sensors is no longer hardcoded in `SENSOR_TYPES`. Instead, it is dynamically set in the `DiscogsSensor`'s `__init__` method, using the currency symbol extracted from the API response.
3.  **Robust Value Parsing**: The parsing logic in the `update` method now more robustly extracts the numeric value from the currency string by finding the first digit or decimal point, ensuring it works regardless of the specific currency symbol used.

This ensures that the collection value sensors display both the correct numeric value and the accurate currency symbol for all users, aligning with their Discogs account configuration.

**Configuration:**

No changes are required to existing `configuration.yaml` entries. The currency localization happens automatically based on the Discogs API response.